### PR TITLE
Fix a bug where stdout was copying stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix stderr copying to stdout bug (https://github.com/schneems/fun_run/pull/3)
+
 ## 0.1.0
 
 - First release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ regex = "1"
 
 [features]
 which_problem = ["dep:which_problem"]
+
+[dev-dependencies]
+pretty_assertions = "1"


### PR DESCRIPTION
In the migration of the Ruby buildpack to use this crate I noticed a regression:

```
  - Running `bash -c "ps aux | grep cargo"`

            rschneeman       26398   0.0  0.0 408417520   9600 s004  S+   11:24AM   0:00.13 /Users/rschneeman/.cargo/bin/cargo-watch watch -c -x ltest
      rschneeman       17561   0.0  0.0 408494848    848 s000  R+    2:39PM   0:00.00 grep cargo
      rschneeman       17559   0.0  0.0 408627920   3088 s000  S+    2:39PM   0:00.00 bash -c ps aux | grep cargo
      rschneeman       15128   0.0  0.0 408433904  10176 s006  S+    2:35PM   0:00.40 /Users/rschneeman/.cargo/bin/cargo-watch watch -c -x ltest

  - Done (< 0.1s)
```

I isolated it to the `fun_run` PR https://github.com/heroku/buildpacks-ruby/pull/232 and after some debugging found it was due to accidentally copying `child.stdout` for `child_stderr`. I added a test that verifies that stderr is redirected correctly.