### PR TITLE
Implement std::error::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.2.0
+
+- Add `std::error::Error` trait to `CmdError` (https://github.com/schneems/fun_run/pull/8)
+
 ## 0.1.3
 
 - Update docs on crates.io (https://github.com/schneems/fun_run/pull/7)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,15 @@ impl Display for CmdError {
     }
 }
 
+impl std::error::Error for CmdError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CmdError::SystemError(_, io_err) => Some(io_err),
+            CmdError::NonZeroExitNotStreamed(_) | CmdError::NonZeroExitAlreadyStreamed(_) => None,
+        }
+    }
+}
+
 impl CmdError {
     /// Returns a display representation of the command that failed
     ///


### PR DESCRIPTION
I want to use this in a `Box<dyn Error>` but the error trait was missing an implementation.

From https://doc.rust-lang.org/std/error/trait.Error.html#method.source

> Errors may provide cause information. Error::source() is generally used when errors cross “abstraction boundaries”. If one module must report an error that is caused by an error from a lower-level module, it can allow accessing that error via Error::source(). This makes it possible for the high-level module to provide its own errors while also revealing some of the implementation for debugging.