### PR TITLE
Add accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
 
-- Add `NamedOutput::output()` which returns `&Output`.
-- Add `impl From<&NamedOutput> for &Output` in addition to the existing `impl From<NamedOutput> for Output`.
-- Add `NamedOutput::stdout()` and `stderr()` to return references to the original `Vec<u8>`. This is in addition to `stdout_lossy` and `stderr_lossy` functions that return `String`.
-- Add `CmdError::status()` to return an `ExitStatus`
+- Add `NamedOutput::output()` which returns `&Output`. (https://github.com/schneems/fun_run/pull/10)
+- Add `impl From<&NamedOutput> for &Output` in addition to the existing `impl From<NamedOutput> for Output`. (https://github.com/schneems/fun_run/pull/10)
+- Add `NamedOutput::stdout()` and `stderr()` to return references to the original `Vec<u8>`. This is in addition to `stdout_lossy` and `stderr_lossy` functions that return `String`. (https://github.com/schneems/fun_run/pull/10)
+- Add `CmdError::status()` to return an `ExitStatus` (https://github.com/schneems/fun_run/pull/10)
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Add `NamedOutput::output()` which returns `&Output`.
+- Add `impl From<&NamedOutput> for &Output` in addition to the existing `impl From<NamedOutput> for Output`.
+- Add `NamedOutput::stdout()` and `stderr()` to return references to the original `Vec<u8>`. This is in addition to `stdout_lossy` and `stderr_lossy` functions that return `String`.
+- Add `CmdError::status()` to return an `ExitStatus`
+
 ## 0.2.0
 
 - Add `std::error::Error` trait to `CmdError` (https://github.com/schneems/fun_run/pull/8)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ include = ["src/**/*", "LICENSE", "README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1"
 which_problem = { version = "0.1", optional = true }
 regex = "1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use command::output_and_write_streams;
-use lazy_static::lazy_static;
+use regex::Regex;
 use std::ffi::OsString;
 use std::fmt::Display;
 use std::io::Write;
@@ -9,6 +9,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Output;
+use std::sync::LazyLock;
 #[cfg(feature = "which_problem")]
 use which_problem::Which;
 
@@ -310,10 +311,9 @@ impl From<NamedOutput> for Output {
     }
 }
 
-lazy_static! {
-    // https://github.com/jimmycuadra/rust-shellwords/blob/d23b853a850ceec358a4137d5e520b067ddb7abc/src/lib.rs#L23
-    static ref QUOTE_ARG_RE: regex::Regex = regex::Regex::new(r"([^A-Za-z0-9_\-.,:/@\n])").expect("Internal error:");
-}
+// https://github.com/jimmycuadra/rust-shellwords/blob/d23b853a850ceec358a4137d5e520b067ddb7abc/src/lib.rs#L23
+static QUOTE_ARG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([^A-Za-z0-9_\-.,:/@\n])").expect("clippy checked"));
 
 /// Converts a command and its arguments into a user readable string
 ///


### PR DESCRIPTION
In the process of working on the buildpacks-jvm repo I found that converting from code that used `Output` and `ExitStatus` worked but was less than ergonomic. This PR adds some easier accessors for things:

- Add `NamedOutput::output()` which returns `&Output`.
- Add `impl From<&NamedOutput> for &Output` in addition to the existing `impl From<NamedOutput> for Output`.
- Add `NamedOutput::stdout()` and `stderr()` to return references to the original `Vec<u8>`. This is in addition to `stdout_lossy` and `stderr_lossy` functions that return `String`.
- Add `CmdError::status()` to return an `ExitStatus`