### PR TITLE
Implement CommandWithName for &mut NamedCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.5.0
+
 - Add `impl CommandWithName for &mut NamedCommand` in addition to `NamedCommand` (https://github.com/schneems/fun_run/pull/14)
 
 ## 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `impl CommandWithName for &mut NamedCommand` in addition to `NamedCommand` (https://github.com/schneems/fun_run/pull/14)
+
 ## 0.4.0
 
 - Add `impl CommandWithName for &mut Command` in addition to `Command` (https://github.com/schneems/fun_run/pull/12)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fun_run"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "The fun way to run your Rust Comand"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,16 @@ impl CommandWithName for NamedCommand<'_> {
     }
 }
 
+impl CommandWithName for &mut NamedCommand<'_> {
+    fn name(&mut self) -> String {
+        self.name.to_string()
+    }
+
+    fn mut_cmd(&mut self) -> &mut Command {
+        self.command
+    }
+}
+
 /// Holds a the `Output` of a command's execution along with it's "name"
 ///
 /// When paired with `CmdError` a `Result<NamedOutput, CmdError>` will retain the


### PR DESCRIPTION
Fixes

```
$ cargo test
   Compiling heroku-ruby-buildpack v0.0.0 (/Users/rschneeman/Documents/projects/work/buildpacks-ruby/buildpacks/ruby)
error[E0277]: the trait bound `&NamedCommand<'_>: CommandWithName` is not satisfied
   --> buildpacks/ruby/src/layers/bundle_install_layer.rs:95:29
    |
95  |                 .stream_cmd(&cmd)
    |                  ---------- ^^^^ the trait `CommandWithName` is not implemented for `&NamedCommand<'_>`
    |                  |
    |                  required by a bound introduced by this call
    |
```