### PR TITLE
Add a way to make a NamedCommand w/o renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.6.0
+
+- Add `impl<'a> From<&'a mut Command> for NamedCommand<'a>` to construct a `NamedCommand` from a regular command reference without renaming it. This is useful when "shortening" names of commands (https://github.com/schneems/fun_run/pull/15)
+
 ## 0.5.0
 
 - Add `impl CommandWithName for &mut NamedCommand` in addition to `NamedCommand` (https://github.com/schneems/fun_run/pull/14)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fun_run"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "The fun way to run your Rust Comand"


### PR DESCRIPTION
Adds `impl<'a> From<&'a mut Command> for NamedCommand<'a>` to construct a `NamedCommand` from a regular command reference without renaming it. This is useful when "shortening" names of commands.