### PR TITLE
Add NamedOutput::for_test for constructing synthetic outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add `NamedOutput::for_test` to construct a synthetic `NamedOutput` without running a process. Useful for testing code that inspects a `NamedOutput`/`CmdError` (https://github.com/schneems/fun_run/pull/22)
 - Update documentation (https://github.com/schneems/fun_run/pull/16)
 
 ## 0.6.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,6 +593,42 @@ pub struct NamedOutput {
 }
 
 impl NamedOutput {
+    /// Builds a synthetic [NamedOutput] from parts, without running a process.
+    ///
+    /// This is intended for tests that need to exercise code which inspects a
+    /// [NamedOutput] or [CmdError] (for example error-classification logic keyed on a
+    /// command's exit code or stderr) without the awkwardness of spawning a real process
+    /// to produce the desired output. Pair it with [NamedOutput::nonzero_captured] or
+    /// [NamedOutput::nonzero_streamed] to obtain a [CmdError].
+    ///
+    /// ```
+    /// use fun_run::NamedOutput;
+    ///
+    /// let error = NamedOutput::for_test("npm ci", 1, "", "npm error code EALLOWGIT")
+    ///     .nonzero_captured()
+    ///     .expect_err("a non-zero exit code is an error");
+    /// assert_eq!(error.status().code(), Some(1));
+    /// ```
+    #[must_use]
+    pub fn for_test(
+        name: impl Into<String>,
+        exit_code: i32,
+        stdout: impl Into<Vec<u8>>,
+        stderr: impl Into<Vec<u8>>,
+    ) -> NamedOutput {
+        NamedOutput {
+            name: name.into(),
+            output: Output {
+                // `ExitStatusExt::from_raw` expects a raw wait status, where the exit code
+                // occupies the high byte, so shift the code into place to make
+                // `ExitStatus::code()` return it.
+                status: ExitStatus::from_raw(exit_code << 8),
+                stdout: stdout.into(),
+                stderr: stderr.into(),
+            },
+        }
+    }
+
     /// Check status and convert into an error if nonzero (include output in error)
     ///
     /// Because the [NamedOutput] does not contain information about whether it was originally
@@ -1072,5 +1108,32 @@ impl std::error::Error for IoErrorAnnotation {
 
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn for_test_builds_named_output_from_parts() {
+        let output = NamedOutput::for_test("npm ci", 1, "out", "boom");
+
+        assert_eq!(output.name(), "npm ci");
+        assert_eq!(output.status().code(), Some(1));
+        assert_eq!(output.stdout_lossy(), "out");
+        assert_eq!(output.stderr_lossy(), "boom");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn for_test_nonzero_converts_into_error() {
+        let error = NamedOutput::for_test("npm ci", 1, "", "boom")
+            .nonzero_captured()
+            .expect_err("a non-zero exit code should produce a CmdError");
+
+        assert!(matches!(error, CmdError::NonZeroExitNotStreamed(_)));
+        assert_eq!(error.status().code(), Some(1));
     }
 }


### PR DESCRIPTION
Tests that exercise code which classifies a command failure — say, branching on a `CmdError`'s exit code or matching against its stderr — currently have no clean way to produce a `NamedOutput` or `CmdError` with specific contents. Every constructor path runs a real process, and the one from-parts door, `nonzero_captured`, still requires hand-building a `std::process::Output`. On unix that means knowing `ExitStatus` has no portable constructor and reaching for `ExitStatus::from_raw(code << 8)` — the raw wait-status encoding, where the exit code lives in the high byte. That's obscure enough that callers tend to shell out to a throwaway subprocess instead, just to get a realistic failure.

`NamedOutput::for_test(name, exit_code, stdout, stderr)` provides that missing constructor and hides the wait-status encoding, so a test can build a `NamedOutput` directly and, via the existing `nonzero_captured`/`nonzero_streamed` helpers, a `CmdError` — no subprocess required.

See:
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html
- https://man7.org/linux/man-pages/man2/wait.2.html