### PR TITLE
Add an easier way to make `NamedOutput` for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add Windows support: the crate now compiles on `*-pc-windows-*` targets, verified in CI via a cross-compile clippy job. The optional `which_problem` feature remains Unix-only. (https://github.com/schneems/fun_run/pull/26)
 - Fix `CmdError::status()` and the `impl From<CmdError> for NamedOutput` conversion so a failed-to-launch command (the `CmdError::SystemError` variant) returns a decodable, shell-conventional exit code (127 not-found, 126 not-executable, 1 otherwise) instead of a raw errno that could decode as a signal. The status is still synthetic (the command never ran) and only guaranteed to be non-zero, so prefer inspecting the underlying `std::io::Error` and its `ErrorKind` directly rather than relying on the exact code. (https://github.com/schneems/fun_run/pull/25)
 - Set the minimum supported Rust version (MSRV) to 1.87. This is required by the `std::io::ErrorKind` variants used to map launch failures to exit codes, and by the optional `which_problem` dependency which relies on `OsStr::display` (stabilized in 1.87). (https://github.com/schneems/fun_run/pull/25)
+- Add `fun_run::OutputWithName` extension trait to construct a synthetic `NamedOutput` without running a process. Useful for testing code that inspects a `NamedOutput`/`CmdError` (https://github.com/schneems/fun_run/pull/23)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `CmdError::status()` and the `impl From<CmdError> for NamedOutput` conversion so a failed-to-launch command (the `CmdError::SystemError` variant) returns a decodable, shell-conventional exit code (127 not-found, 126 not-executable, 1 otherwise) instead of a raw errno that could decode as a signal. The status is still synthetic (the command never ran) and only guaranteed to be non-zero, so prefer inspecting the underlying `std::io::Error` and its `ErrorKind` directly rather than relying on the exact code. (https://github.com/schneems/fun_run/pull/25)
 - Set the minimum supported Rust version (MSRV) to 1.87. This is required by the `std::io::ErrorKind` variants used to map launch failures to exit codes, and by the optional `which_problem` dependency which relies on `OsStr::display` (stabilized in 1.87). (https://github.com/schneems/fun_run/pull/25)
 - Add `fun_run::OutputWithName` extension trait to construct a synthetic `NamedOutput` without running a process. Useful for testing code that inspects a `NamedOutput`/`CmdError` (https://github.com/schneems/fun_run/pull/23)
+- Add `fun_run::ExitStatusFromCode` extension trait as an ergonomic construct to build an `ExitStatus` without bit shifting (https://github.com/schneems/fun_run/pull/23)
 
 ## 0.6.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,17 +600,14 @@ impl CommandWithName for &mut NamedCommand<'_> {
 /// assert_eq!(String::from("exit 0"), named.name());
 /// ```
 ///
-/// For generating an [`Output`] with a non-zero status on Unix you can use [`std::os::unix::process::ExitStatusExt::from_raw`]
-/// which needs to be bit shifted by 8 bits to get the same status code back:
+/// For generating an [`Output`] with a non-zero status on Unix you can use [`ExitStatusFromCode::from_code`],
+/// which builds the `ExitStatus` from a plain exit code without you having to bit-shift the raw wait status yourself:
 ///
 /// ```
-/// use fun_run::OutputWithName;
-/// use std::os::unix::process::ExitStatusExt;
+/// use fun_run::{OutputWithName, ExitStatusFromCode};
 ///
-/// // The `ExitStatus::from_raw` input is expected to come from `wait` https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
-/// // with `WEXITSTATUS` being the code we care about so it needs to be shifted by 8 bits.
 /// let output = std::process::Output {
-///     status: std::process::ExitStatus::from_raw(42 << 8),
+///     status: std::process::ExitStatus::from_code(42),
 ///     stdout: Vec::new(),
 ///     stderr: Vec::new()
 /// };
@@ -635,7 +632,70 @@ impl OutputWithName for Output {
     }
 }
 
-/// Holds a the `Output` of a command's execution along with it's "name"
+/// Extension trait for [`ExitStatus`] to build an instance based on exit code
+///
+/// Confusingly the [`std::os::unix::process::ExitStatusExt::from_raw`] function does NOT return its own input on Unix:
+///
+/// ```
+/// # #[cfg(unix)] {
+/// use std::process::ExitStatus;
+/// use std::os::unix::process::ExitStatusExt;
+///
+/// let status = ExitStatus::from_raw(41);
+/// assert_eq!(None, status.code());
+///
+/// // The input has to be bit-shifted by 8 to get it to work:
+/// let status = ExitStatus::from_raw(41<<8);
+/// assert_eq!(Some(41), status.code());
+/// # }
+/// ```
+///
+/// That's because the input isn't an exit code but rather data structure from `wait` <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html>.
+/// To input a known status code, you can bitshift it by 8 OR you can use this nice helper extension
+/// trait:
+///
+/// ```
+/// use std::process::ExitStatus;
+/// use fun_run::ExitStatusFromCode;
+///
+/// let status = ExitStatus::from_code(41);
+/// assert_eq!(Some(41), status.code());
+/// ```
+///
+/// The main use case for generating a manual [`ExitStatus`] is for unit testing.
+pub trait ExitStatusFromCode {
+    /// Build an [`ExitStatus`] from an exit code.
+    ///
+    /// Takes a [`u8`] on Unix because exit codes there are limited to
+    /// `0..=255`. Non-uniform type signature with windows provides infallible api
+    /// for a correctness tradeoff.
+    #[cfg(unix)]
+    #[must_use]
+    fn from_code(code: u8) -> ExitStatus;
+
+    /// Build an [`ExitStatus`] from an exit code.
+    ///
+    /// Takes a [`u32`] on Windows because exit codes there are full 32-bit
+    /// `DWORD` values.  Non-uniform type signature with unix provides infallible api
+    /// for a correctness tradeoff.
+    #[cfg(windows)]
+    #[must_use]
+    fn from_code(code: u32) -> ExitStatus;
+}
+
+impl ExitStatusFromCode for ExitStatus {
+    #[cfg(unix)]
+    fn from_code(code: u8) -> ExitStatus {
+        status_from_code(code.into())
+    }
+
+    #[cfg(windows)]
+    fn from_code(code: u32) -> ExitStatus {
+        status_from_code(code)
+    }
+}
+
+/// Holds a the `Output` of a command's execution along with its "name"
 ///
 /// When paired with `CmdError` a `Result<NamedOutput, CmdError>` will retain the
 /// "name" of the command regardless of succss or failure.
@@ -947,6 +1007,11 @@ impl From<CmdError> for NamedOutput {
     }
 }
 
+#[cfg(not(any(unix, windows)))]
+compile_error!(
+    "fun_run constructs `ExitStatus` values and only supports `unix` and `windows` targets"
+);
+
 fn status_from_code(code: u32) -> ExitStatus {
     #[cfg(unix)]
     {
@@ -1176,9 +1241,9 @@ mod tests {
 
     #[test]
     fn test_status_from_code() {
-        for code in 0..=255i32 {
-            let status = status_from_code(code as u32);
-            assert_eq!(Some(code), status.code());
+        for code in 0..=255 {
+            let status = ExitStatus::from_code(code);
+            assert_eq!(Some(code as i32), status.code());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@ impl ExitStatusFromCode for ExitStatus {
     }
 }
 
-/// Holds a the `Output` of a command's execution along with its "name"
+/// Holds an [`Output`] of a command's execution along with its "name"
 ///
 /// When paired with `CmdError` a `Result<NamedOutput, CmdError>` will retain the
 /// "name" of the command regardless of succss or failure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,6 +581,60 @@ impl CommandWithName for &mut NamedCommand<'_> {
     }
 }
 
+/// Extension trait for `Output` to generate `NamedOutput`
+///
+/// The primary use case is exercising a function that takes [`NamedOutput`] in its arguments in a test.
+///
+/// ## Example
+///
+/// ```
+/// use fun_run::OutputWithName;
+///
+/// let output = std::process::Output {
+///     status: std::process::ExitStatus::default(),
+///     stdout: Vec::new(),
+///     stderr: Vec::new()
+/// };
+///
+/// let named: fun_run::NamedOutput = output.named("exit 0");
+/// assert_eq!(String::from("exit 0"), named.name());
+/// ```
+///
+/// For generating an [`Output`] with a non-zero status on Unix you can use [`std::os::unix::process::ExitStatusExt::from_raw`]
+/// which needs to be bit shifted by 8 bits to get the same status code back:
+///
+/// ```
+/// use fun_run::OutputWithName;
+/// use std::os::unix::process::ExitStatusExt;
+///
+/// // The `ExitStatus::from_raw` input is expected to come from `wait` https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
+/// // with `WEXITSTATUS` being the code we care about so it needs to be shifted by 8 bits.
+/// let output = std::process::Output {
+///     status: std::process::ExitStatus::from_raw(42 << 8),
+///     stdout: Vec::new(),
+///     stderr: Vec::new()
+/// };
+///
+/// assert_eq!(42, output.status.code().unwrap());
+///
+/// let named: fun_run::NamedOutput = output.named("exit 42");
+/// let result = named.nonzero_captured();
+/// assert!(result.is_err());
+/// ```
+pub trait OutputWithName {
+    #[must_use]
+    fn named(self, s: impl AsRef<str>) -> NamedOutput;
+}
+
+impl OutputWithName for Output {
+    fn named(self, s: impl AsRef<str>) -> NamedOutput {
+        NamedOutput {
+            name: s.as_ref().to_string(),
+            output: self,
+        }
+    }
+}
+
 /// Holds a the `Output` of a command's execution along with it's "name"
 ///
 /// When paired with `CmdError` a `Result<NamedOutput, CmdError>` will retain the


### PR DESCRIPTION
The primary motivator is unit testing a function that takes `NamedOutput` without needing to actually run a command (which is expensive, compared to constructing a struct). It's currently possible to generate a `NamedOutput` but it's a bit tortured:

```
let named = nonzero_captured(name, output).unwrap_or_else(NamedOutput::from);
```

This is an alternative to https://github.com/schneems/fun_run/pull/22 that uses an extension trait instead of introducing a new function. It's more explicit to construct an exact `Output` struct and then convert it into a `NamedOutput` by providing only a name. Right now, a `NamedOutput` is somewhat "hard to forge" in that it signals "I (likely) ran, I was given an intentional name, and am otherwise real." With PR #22, the only thing discouraging `NamedOutput::for_test` from showing up in non-test code is its name. This approach instead requires the developer to bring the correct extension into scope first and then fully construct the `Output` before converting it, making the construction as explicit and visible as possible. We could also add a feature gate for it, but I don't think that's necessary.
