### PR TITLE
Fix Cargo-rdme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.2
       - name: Install cargo readme
-        run: cargo install cargo-rdme
+        run: |
+          cargo install cargo-rdme
+          cargo rdme install-rust-toolchain-for-intralinks
       - name: Check if README.md is up-to-date (see README.md for updating instructions)
         run: cargo rdme --check

--- a/README.md
+++ b/README.md
@@ -295,13 +295,13 @@ cmd.output()
 
 Here's some fun functions you can use to help you run:
 
-- [`on_system_error`] - Convert `std::io::Error` into `CmdError`
-- [`nonzero_streamed`] - Produces a `NamedOutput` from `Output` that has already been streamd to
+- [`on_system_error`](https://docs.rs/fun_run/latest/fun_run/fn.on_system_error.html) - Convert `std::io::Error` into `CmdError`
+- [`nonzero_streamed`](https://docs.rs/fun_run/latest/fun_run/fn.nonzero_streamed.html) - Produces a `NamedOutput` from `Output` that has already been streamd to
   the user
-- [`nonzero_captured`] - Like `nonzero_streamed` but for when the user hasn't already seen the
+- [`nonzero_captured`](https://docs.rs/fun_run/latest/fun_run/fn.nonzero_captured.html) - Like `nonzero_streamed` but for when the user hasn't already seen the
   output
-- [`display`] - Converts an `&mut Command` into a human readable string
-- [`display_with_env_keys`] - Like `display` but selectively shows environment variables.
+- [`display`](https://docs.rs/fun_run/latest/fun_run/fn.display.html) - Converts an `&mut Command` into a human readable string
+- [`display_with_env_keys`](https://docs.rs/fun_run/latest/fun_run/fn.display_with_env_keys.html) - Like `display` but selectively shows environment variables.
 
 ## Async
 


### PR DESCRIPTION
Cargo-rdme 2 add added the ability to use interlinks and since CI is using the latest version (unpinned) it tries to generate them without the required toolchain:

```
Run cargo rdme --check
error: failed to transform intralinks: rust toolchain not installed: nightly-2026-06-22

`cargo-rdme` needs nightly-2026-06-22 to do intralink resolution. To install it run:

    rustup toolchain install nightly-2026-06-22

or, equivalently, run `cargo rdme install-rust-toolchain-for-intralinks`.
```