### PR TITLE
Improve ExitStatus behavior when command fails to launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: cargo test --all-features
 
   msrv:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: cargo +1.83 test --all-features
 
   readme-updated:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
       - name: Run unit tests
         run: cargo test --all-features
 
+  msrv:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install MSRV toolchain
+        # Pinned to the `rust-version` declared in Cargo.toml. Unlike the other
+        # jobs (which `rustup update` to latest stable), this enforces the MSRV
+        # and catches code that silently raises the floor.
+        run: rustup toolchain install 1.83 --profile minimal
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.2
+      - name: Build and test on MSRV
+        run: cargo +1.83 test --all-features
+
   readme-updated:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
         # Pinned to the `rust-version` declared in Cargo.toml. Unlike the other
         # jobs (which `rustup update` to latest stable), this enforces the MSRV
         # and catches code that silently raises the floor.
-        run: rustup toolchain install 1.83 --profile minimal
+        run: rustup toolchain install 1.87 --profile minimal
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.2
       - name: Build and test on MSRV
-        run: cargo +1.83 test --all-features
+        run: cargo +1.87 test --all-features
 
   readme-updated:
     runs-on: ubuntu-26.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check_publishable:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,7 +23,7 @@ jobs:
         run: cargo publish --dry-run
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,7 +45,7 @@ jobs:
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
 
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update documentation (https://github.com/schneems/fun_run/pull/16)
 - Fix `CmdError::status()` and the `impl From<CmdError> for NamedOutput` conversion so a failed-to-launch command (the `CmdError::SystemError` variant) returns a decodable, shell-conventional exit code (127 not-found, 126 not-executable, 1 otherwise) instead of a raw errno that could decode as a signal. The status is still synthetic (the command never ran) and only guaranteed to be non-zero, so prefer inspecting the underlying `std::io::Error` and its `ErrorKind` directly rather than relying on the exact code. (https://github.com/schneems/fun_run/pull/25)
+- Set the minimum supported Rust version (MSRV) to 1.83, required by the `std::io::ErrorKind` variants used to map launch failures to exit codes. (https://github.com/schneems/fun_run/pull/25)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Update documentation (https://github.com/schneems/fun_run/pull/16)
+- Clarify that the `ExitStatus` from `CmdError::status()` and from the `impl From<CmdError> for NamedOutput` conversion is synthetic for the `CmdError::SystemError` variant (the command never ran). In that case the status is fabricated from the underlying `std::io::Error` and is only guaranteed to be non-zero. The exact code should not be relied upon, instead use the `ErrorKind` enum directly. (https://github.com/schneems/fun_run/pull/24)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Update documentation (https://github.com/schneems/fun_run/pull/16)
 - Fix `CmdError::status()` and the `impl From<CmdError> for NamedOutput` conversion so a failed-to-launch command (the `CmdError::SystemError` variant) returns a decodable, shell-conventional exit code (127 not-found, 126 not-executable, 1 otherwise) instead of a raw errno that could decode as a signal. The status is still synthetic (the command never ran) and only guaranteed to be non-zero, so prefer inspecting the underlying `std::io::Error` and its `ErrorKind` directly rather than relying on the exact code. (https://github.com/schneems/fun_run/pull/25)
-- Set the minimum supported Rust version (MSRV) to 1.83, required by the `std::io::ErrorKind` variants used to map launch failures to exit codes. (https://github.com/schneems/fun_run/pull/25)
+- Set the minimum supported Rust version (MSRV) to 1.87. This is required by the `std::io::ErrorKind` variants used to map launch failures to exit codes, and by the optional `which_problem` dependency which relies on `OsStr::display` (stabilized in 1.87). (https://github.com/schneems/fun_run/pull/25)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Update documentation (https://github.com/schneems/fun_run/pull/16)
-- Clarify that the `ExitStatus` from `CmdError::status()` and from the `impl From<CmdError> for NamedOutput` conversion is synthetic for the `CmdError::SystemError` variant (the command never ran). In that case the status is fabricated from the underlying `std::io::Error` and is only guaranteed to be non-zero. The exact code should not be relied upon, instead use the `ErrorKind` enum directly. (https://github.com/schneems/fun_run/pull/24)
+- Fix `CmdError::status()` and the `impl From<CmdError> for NamedOutput` conversion so a failed-to-launch command (the `CmdError::SystemError` variant) returns a decodable, shell-conventional exit code (127 not-found, 126 not-executable, 1 otherwise) instead of a raw errno that could decode as a signal. The status is still synthetic (the command never ran) and only guaranteed to be non-zero, so prefer inspecting the underlying `std::io::Error` and its `ErrorKind` directly rather than relying on the exact code. (https://github.com/schneems/fun_run/pull/25)
 
 ## 0.6.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fun_run"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.87"
 license = "MIT"
 description = "The fun way to run your Rust Comand"
 keywords = ["command", "execute", "run", "stream", "CLI"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fun_run"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.83"
 license = "MIT"
 description = "The fun way to run your Rust Comand"
 keywords = ["command", "execute", "run", "stream", "CLI"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,9 +863,7 @@ impl CmdError {
     /// If the command failed and no error can be produced a default non-zero value will be returned
     pub fn status(&self) -> ExitStatus {
         match self {
-            CmdError::SystemError(_, error) => {
-                ExitStatus::from_raw(error.raw_os_error().unwrap_or(-1))
-            }
+            CmdError::SystemError(_, error) => status_from_error(error),
             CmdError::NonZeroExitNotStreamed(named_output) => named_output.status().to_owned(),
             CmdError::NonZeroExitAlreadyStreamed(named_output) => named_output.status().to_owned(),
         }
@@ -878,7 +876,7 @@ impl From<CmdError> for NamedOutput {
             CmdError::SystemError(name, error) => NamedOutput {
                 name,
                 output: Output {
-                    status: ExitStatus::from_raw(error.raw_os_error().unwrap_or(-1)),
+                    status: status_from_error(&error),
                     stdout: Vec::new(),
                     stderr: error.to_string().into_bytes(),
                 },
@@ -887,6 +885,10 @@ impl From<CmdError> for NamedOutput {
             | CmdError::NonZeroExitAlreadyStreamed(named) => named,
         }
     }
+}
+
+fn status_from_error(error: &std::io::Error) -> ExitStatus {
+    ExitStatus::from_raw(error.raw_os_error().unwrap_or(-1))
 }
 
 fn display_out_or_empty(contents: &[u8]) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,9 +858,13 @@ impl CmdError {
         }
     }
 
-    /// Returns the OS [ExitStatus] if one was provided
+    /// Returns the OS [`ExitStatus`] of the command.
     ///
-    /// If the command failed and no error can be produced a default non-zero value will be returned
+    /// For [`CmdError::SystemError`] the command never ran, so there is no real
+    /// OS exit status. In that case a value derived from the underlying
+    /// [`std::io::Error`] is returned. It is only guaranteed to be non-zero, so
+    /// prefer inspecting the [`std::io::Error`] and its [`std::io::ErrorKind`]
+    /// directly rather than relying on the exact code.
     pub fn status(&self) -> ExitStatus {
         match self {
             CmdError::SystemError(_, error) => status_from_error(error),
@@ -871,6 +875,9 @@ impl CmdError {
 }
 
 impl From<CmdError> for NamedOutput {
+    /// When the error is a [`CmdError::SystemError`], the resulting
+    /// [`ExitStatus`] is synthetic and imprecise. The only stability guarantee
+    /// is that it will be non-zero.
     fn from(value: CmdError) -> Self {
         match value {
             CmdError::SystemError(name, error) => NamedOutput {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,7 +1103,7 @@ impl std::error::Error for IoErrorAnnotation {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]
@@ -1112,5 +1112,23 @@ mod test {
             let status = status_from_code(i);
             assert_eq!(i, status.code().unwrap());
         }
+    }
+
+    #[test]
+    fn maps_error_kinds_to_shell_codes() {
+        use std::io::{Error, ErrorKind};
+
+        assert_eq!(
+            status_from_error(&Error::from(ErrorKind::NotFound)).code(),
+            Some(127)
+        );
+        assert_eq!(
+            status_from_error(&Error::from(ErrorKind::PermissionDenied)).code(),
+            Some(126)
+        );
+        assert_eq!(
+            status_from_error(&Error::from(ErrorKind::Other)).code(),
+            Some(1)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,8 +887,26 @@ impl From<CmdError> for NamedOutput {
     }
 }
 
+fn status_from_code(code: i32) -> ExitStatus {
+    ExitStatus::from_raw((code & 0xff) << 8)
+}
+
 fn status_from_error(error: &std::io::Error) -> ExitStatus {
-    ExitStatus::from_raw(error.raw_os_error().unwrap_or(-1))
+    use std::io::ErrorKind;
+
+    let code = match error.kind() {
+        ErrorKind::NotFound => 127, // ENOENT
+        // Found but not executable -> "cannot execute"
+        ErrorKind::PermissionDenied      // EACCES
+        | ErrorKind::IsADirectory        // EISDIR
+        | ErrorKind::NotADirectory       // ENOTDIR
+        | ErrorKind::ArgumentListTooLong // E2BIG
+        | ErrorKind::OutOfMemory         // ENOMEM
+        | ErrorKind::ExecutableFileBusy  // ETXTBSY
+        => 126,
+        _ => 1,
+    };
+    status_from_code(code)
 }
 
 fn display_out_or_empty(contents: &[u8]) -> String {
@@ -1074,5 +1092,18 @@ impl std::error::Error for IoErrorAnnotation {
 
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_status_from_code() {
+        for i in 0..=255 {
+            let status = status_from_code(i);
+            assert_eq!(i, status.code().unwrap());
+        }
     }
 }


### PR DESCRIPTION
PR #22 highlighted the surprising behavior of `ExitStatus::from_raw` to fix it we need to bitshift. While investigating that, this lossy conversion came into focus. It seems better to map discrete error types to known/common error statuses.