### PR TITLE
Add signal output line to `CmdError` display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `fun_run::OutputWithName` extension trait to construct a synthetic `NamedOutput` without running a process. Useful for testing code that inspects a `NamedOutput`/`CmdError` (https://github.com/schneems/fun_run/pull/23)
 - Add `fun_run::ExitStatusFromCode` extension trait as an ergonomic construct to build an `ExitStatus` without bit shifting (https://github.com/schneems/fun_run/pull/23)
 - Improve `exit status` display for `CmdError`. On Unix, when a signal kills a process it does not have a status code `ExitStatus::code()` returns `None`. Previously we were defaulting to a value of `1` for that case. Now, we are replicating the behavior of bash by adding `128` to the signal number such that `SIGTERM` becomes `143`.
+- Add signal output line to `CmdError` display. Signals documented by POSIX are printed with their human-readable name `signal: 15 (SIGTERM)`. Other signals print only the number `signal: 126`.
 
 ## 0.6.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -928,6 +928,40 @@ fn bashify(status: &ExitStatus) -> i32 {
     }
 }
 
+/// Returns a printable description of the signal that killed a process
+/// (if it was killed by a signal)
+fn signal_line(status: &ExitStatus) -> Option<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        status.signal().map(|signal| {
+            // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/kill.html
+            let name = match signal {
+                1 => "SIGHUP",
+                2 => "SIGINT",
+                3 => "SIGQUIT",
+                6 => "SIGABRT",
+                9 => "SIGKILL",
+                14 => "SIGALRM",
+                15 => "SIGTERM",
+                _ => "",
+            };
+
+            if name.is_empty() {
+                format!("signal: {signal}")
+            } else {
+                format!("signal: {signal} ({name})")
+            }
+        })
+    }
+    #[cfg(windows)]
+    {
+        let _ = status;
+        None
+    }
+}
+
 impl Display for CmdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -944,6 +978,9 @@ impl Display for CmdError {
                     "exit status: {status}",
                     status = bashify(&named_output.output.status)
                 )?;
+                if let Some(signal_line) = signal_line(&named_output.output.status) {
+                    writeln!(f, "{signal_line}")?;
+                }
                 writeln!(f, "stdout: {stdout}",)?;
                 write!(f, "stderr: {stderr}",)
             }
@@ -954,6 +991,9 @@ impl Display for CmdError {
                     "exit status: {status}",
                     status = bashify(&named_output.output.status)
                 )?;
+                if let Some(signal_line) = signal_line(&named_output.output.status) {
+                    writeln!(f, "{signal_line}")?;
+                }
                 writeln!(f, "stdout: <see above>")?;
                 write!(f, "stderr: <see above>")
             }
@@ -1298,7 +1338,34 @@ mod tests {
         use std::os::unix::process::ExitStatusExt;
 
         let sigterm = 15;
-        let code = bashify(&ExitStatus::from_raw(sigterm));
+        let status = ExitStatus::from_raw(sigterm);
+        assert_eq!(None, status.code());
+        assert_eq!(Some(15), status.signal());
+
+        let code = bashify(&status);
         assert_eq!(143, code);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn maps_signal_to_human_readable_output() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let sigterm = 15;
+        let status = ExitStatus::from_raw(sigterm);
+        assert_eq!(None, status.code());
+        assert_eq!(Some(15), status.signal());
+
+        assert_eq!(
+            String::from("signal: 15 (SIGTERM)"),
+            signal_line(&status).unwrap()
+        );
+
+        let signal = 126;
+        let status = ExitStatus::from_raw(signal);
+        assert_eq!(None, status.code());
+        assert_eq!(Some(126), status.signal());
+
+        assert_eq!(String::from("signal: 126"), signal_line(&status).unwrap());
     }
 }


### PR DESCRIPTION
Signals documented by POSIX are printed with their human-readable name `signal: 15 (SIGTERM)`. Other signals print only the number `signal: 126`.