### PR TITLE
Introduce CmdError::output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
+
 ## 0.7.0
 
 - Update documentation (https://github.com/schneems/fun_run/pull/16)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,6 +1079,15 @@ impl CmdError {
         }
     }
 
+    /// Returns named output if the command ran
+    pub fn output(&self) -> Option<&NamedOutput> {
+        match self {
+            CmdError::SystemError(_, _) => None,
+            CmdError::NonZeroExitNotStreamed(named_output) => Some(named_output),
+            CmdError::NonZeroExitAlreadyStreamed(named_output) => Some(named_output),
+        }
+    }
+
     /// Returns the OS [`ExitStatus`] of the command.
     ///
     /// For [`CmdError::SystemError`] the command never ran, so there is no real


### PR DESCRIPTION
Getting the captured output off a failed command meant pattern matching on CmdError's variants and knowing which ones carry a `NamedOutput`. `CmdError::output()` now exposes it directly, returning `Some(&NamedOutput)` when the command ran and `None` for SystemError (where it never ran).