### PR TITLE
Introduce nightly features 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,27 @@ jobs:
       - name: Build and test on MSRV
         run: cargo +1.87 test --all-features
 
+  nightly-test:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.9.1
+      - name: Run unit tests on nightly
+        # GitHub's default bash runs with `-o pipefail`, so a cargo failure
+        # (including the gated test failing to compile) still fails this step.
+        run: cargo +nightly test --all-features 2>&1 | tee nightly-test-output.txt
+      - name: Ensure the command_resolved_envs feature was actually exercised
+        # Guards against the build.rs probe silently failing: if detection breaks,
+        # the gated test compiles out, this line is absent, and CI goes red.
+        # Coupled to the test name in src/lib.rs (update both together).
+        run: |
+          grep -q 'get_resolved_envs_detects_nightly_feature ... ok' nightly-test-output.txt \
+            || { echo "::error::command_resolved_envs gated test did not run; feature detection may be broken or the feature changed"; exit 1; }
+
   readme-updated:
     runs-on: ubuntu-26.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
-- Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) and provides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabilized in Rust then `display_with_env_keys` will be deprecated.
+- Introduce `fun_run::display_env_vars()` (for nightly users). This pulls environment variables from the command (using a nightly feature) and provides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabilized in Rust then `display_with_env_keys` will be deprecated.
 - Introduce `named_env_vars` function to the `CommandWithName` trait (for nightly users). This function helps decorating a command's name with the given environment variable keys.
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
 - Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) andprovides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabalized in Rust then `display_with_env_keys` will be deprecated.
+- Introduce `named_keys` function to the `CommandWithName` trait (for nightly users). This function helps decorating a command's name with the given environment variable keys.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
-- Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) andprovides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabalized in Rust then `display_with_env_keys` will be deprecated.
+- Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) and provides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabilized in Rust then `display_with_env_keys` will be deprecated.
 - Introduce `named_keys` function to the `CommandWithName` trait (for nightly users). This function helps decorating a command's name with the given environment variable keys.
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
 - Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) and provides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabilized in Rust then `display_with_env_keys` will be deprecated.
-- Introduce `named_keys` function to the `CommandWithName` trait (for nightly users). This function helps decorating a command's name with the given environment variable keys.
+- Introduce `named_env_vars` function to the `CommandWithName` trait (for nightly users). This function helps decorating a command's name with the given environment variable keys.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Introduce `CmdError::output` for easy retrieval of the named output if the command ran.
+- Introduce `fun_run::display_env_keys()` (for nightly users). This pulls environment variables from the command (using a nightly feature) andprovides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabalized in Rust then `display_with_env_keys` will be deprecated.
 
 ## 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["command", "execute", "run", "stream", "CLI"]
 repository = "https://github.com/schneems/fun_run"
 documentation = "https://docs.rs/fun_run"
 readme = "README.md"
-include = ["src/**/*", "LICENSE", "README.md"]
+include = ["src/**/*", "build.rs", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,3 +23,6 @@ which_problem = ["dep:which_problem"]
 [dev-dependencies]
 indoc = "2.0.7"
 pretty_assertions = "1"
+
+[build-dependencies]
+autocfg = "1"

--- a/README.md
+++ b/README.md
@@ -60,15 +60,6 @@ assert!(
 );
 ```
 
-## Nightly-only items
-
-A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
-nightly toolchain. They depend on the unstable
-[`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
-feature, auto-detected at build time, and are absent on stable. Because
-<https://docs.rs> builds on nightly, these appear in the published docs even
-though stable users cannot use them.
-
 ## Install
 
 ```shell
@@ -218,6 +209,15 @@ info you need to diagnose the underlying issue.
 
 Note that `which_problem` integration is not enabled by default because it outputs information
 about the contents of your disk such as layout and file permissions.
+
+## Nightly-only items
+
+A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
+nightly toolchain. They depend on the unstable
+[`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+feature, auto-detected at build time, and are absent on stable. Because
+<https://docs.rs> builds on nightly, these appear in the published docs even
+though stable users cannot use them.
 
 <!-- cargo-rdme end -->
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ assert!(
 );
 ```
 
+## Nightly-only items
+
+A few items (`display_env_keys` and `CommandWithName::named_keys`) require a
+nightly toolchain. They depend on the unstable
+[`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+feature, auto-detected at build time, and are absent on stable. Because
+<https://docs.rs> builds on nightly, these appear in the published docs even
+though stable users cannot use them.
+
 ## Install
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ assert!(
 
 ## Nightly-only items
 
-A few items (`display_env_keys` and `CommandWithName::named_keys`) require a
+A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
 nightly toolchain. They depend on the unstable
 [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
 feature, auto-detected at build time, and are absent on stable. Because

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,24 @@
+//! Detect support for `command_resolved_envs` <https://github.com/rust-lang/rust/issues/149070>
+//!
+//! Uses `autocfg` to compile a probe with the same rustc the crate is built
+//! with. The probe only succeeds on a toolchain where the unstable
+//! `command_resolved_envs` feature exists (currently nightly).
+
+const PROBE: &str = r#"
+#![feature(command_resolved_envs)]
+pub fn probe() {
+    let cmd = std::process::Command::new("does-not-run");
+    let _ = cmd.get_resolved_envs();
+}
+"#;
+
+fn main() {
+    autocfg::rerun_path("build.rs");
+
+    let ac = autocfg::new();
+    // Declare the cfg for check-cfg so clippy's `--deny warnings` stays quiet.
+    autocfg::emit_possibility("command_resolved_envs");
+    if ac.probe_raw(PROBE).is_ok() {
+        autocfg::emit("command_resolved_envs");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! ## Nightly-only items
 //!
-//! A few items (`display_env_keys` and `CommandWithName::named_env_vars`) require a
+//! A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
 //! nightly toolchain. They depend on the unstable
 //! [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
 //! feature, auto-detected at build time, and are absent on stable. Because
@@ -873,17 +873,22 @@ pub fn display(command: &mut Command) -> String {
 
 /// Converts a command, and specified environment variables to user readable string
 ///
-/// **Note:** Requires a nightly toolchain. This function relies on the unstable
-/// [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
-/// feature, which is auto-detected at build time. On a stable toolchain it does
-/// not exist, so calling it (or referring to it) will not compile.
+/// Takes an environment variable **key** and if it will be used when the command runs
+/// prepends the `<key>=<value>` pair to the front of the command.
 ///
-/// Useful for showing usage of a command that uses environment variables for configuration.
+/// **Warning:** By default a [`Command`] will inherit environment variables from the parent process.
+/// Limit environment variables to non-sensitive keys or use [`Command::env_clear`] and explicitly
+/// [`Command::envs`] to set only what you need.
 ///
 /// This safer alternative to [`display_with_env_keys`] resolves environment variables from
 /// [`Command::get_resolved_envs`]. That function will automatically account for
 /// inherited environment variables and any env modifications such as [`Command::env_clear`]
 /// or [`Command::env_remove`].
+///
+/// **Note:** Requires a nightly toolchain. This function relies on the unstable
+/// [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+/// feature, which is auto-detected at build time. On a stable toolchain it does
+/// not exist, so calling it (or referring to it) will not compile.
 ///
 /// # Examples
 ///
@@ -894,12 +899,12 @@ pub fn display(command: &mut Command) -> String {
 /// let mut command = Command::new("bundle");
 /// command.arg("install").envs([("RAILS_ENV", "production")]);
 ///
-/// let name = fun_run::display_env_keys(&mut command, ["RAILS_ENV"]);
+/// let name = fun_run::display_env_vars(&mut command, ["RAILS_ENV"]);
 /// assert_eq!(String::from(r#"RAILS_ENV="production" bundle install"#), name);
 /// ```
-#[must_use]
 #[cfg(command_resolved_envs)]
-pub fn display_env_keys<T, K>(cmd: &mut Command, keys: T) -> String
+#[must_use]
+pub fn display_env_vars<T, K>(cmd: &mut Command, keys: T) -> String
 where
     T: IntoIterator<Item = K>,
     K: Into<OsString>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,6 +804,12 @@ pub fn display(command: &mut Command) -> String {
 /// let name = fun_run::display_with_env_keys(&mut command, &env, ["RAILS_ENV"]);
 /// assert_eq!(String::from(r#"RAILS_ENV="production" bundle install"#), name);
 /// ```
+///
+/// There's no guarantee that the env provided was passed to construct the Command.
+/// A [`Command`] can also inherit environment variables from the parent.
+///
+/// Note that [`Command::env_clear`] and [`Command::env_remove`] both change the Command's
+/// env var inheritance behavior.
 #[must_use]
 pub fn display_with_env_keys<E, K, V, I, O>(cmd: &mut Command, env: E, keys: I) -> String
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,15 @@
 //! );
 //! ```
 //!
+//! ## Nightly-only items
+//!
+//! A few items (`display_env_keys` and `CommandWithName::named_keys`) require a
+//! nightly toolchain. They depend on the unstable
+//! [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+//! feature, auto-detected at build time, and are absent on stable. Because
+//! <https://docs.rs> builds on nightly, these appear in the published docs even
+//! though stable users cannot use them.
+//!
 //! ## Install
 //!
 //! ```shell
@@ -322,6 +331,11 @@ pub trait CommandWithName {
 
     /// Adds given environment variables to the command's name
     ///
+    /// **Note:** Requires a nightly toolchain. This method relies on the unstable
+    /// [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+    /// feature, which is auto-detected at build time. On a stable toolchain it does
+    /// not exist, so calling it (or referring to it) will not compile.
+    ///
     /// Useful for showing usage of a command that uses environment variables for configuration.
     ///
     /// ## Example
@@ -375,7 +389,7 @@ pub trait CommandWithName {
     ///
     /// This function is NOT (currently) idempotent. Calling it twice will prepend
     /// the same environment variable twice. This behavior might change in the future (such that
-    /// under some conditions is becomes idempotent). Therefore you shouldn't consider this warning
+    /// under some conditions it becomes idempotent). Therefore you shouldn't consider this warning
     /// a stability guarantee.
     #[cfg(command_resolved_envs)]
     #[allow(clippy::needless_lifetimes)]
@@ -853,6 +867,11 @@ pub fn display(command: &mut Command) -> String {
 }
 
 /// Converts a command, and specified environment variables to user readable string
+///
+/// **Note:** Requires a nightly toolchain. This function relies on the unstable
+/// [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+/// feature, which is auto-detected at build time. On a stable toolchain it does
+/// not exist, so calling it (or referring to it) will not compile.
 ///
 /// Useful for showing usage of a command that uses environment variables for configuration.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,8 @@
 
 use command::output_and_write_streams;
 use regex::Regex;
-use std::ffi::OsString;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::io::Write;
 use std::process::Command;
@@ -231,9 +232,6 @@ use std::process::Output;
 use std::sync::LazyLock;
 #[cfg(feature = "which_problem")]
 use which_problem::Which;
-
-#[cfg(command_resolved_envs)]
-use std::{collections::HashMap, ffi::OsStr};
 
 mod command;
 
@@ -768,20 +766,48 @@ static QUOTE_ARG_RE: LazyLock<Regex> =
 pub fn display(command: &mut Command) -> String {
     vec![command.get_program().to_string_lossy().to_string()]
         .into_iter()
-        .chain(
-            command
-                .get_args()
-                .map(std::ffi::OsStr::to_string_lossy)
-                .map(|arg| {
-                    if QUOTE_ARG_RE.is_match(&arg) {
-                        format!("{arg:?}")
-                    } else {
-                        format!("{arg}")
-                    }
-                }),
-        )
+        .chain(command.get_args().map(OsStr::to_string_lossy).map(|arg| {
+            if QUOTE_ARG_RE.is_match(&arg) {
+                format!("{arg:?}")
+            } else {
+                format!("{arg}")
+            }
+        }))
         .collect::<Vec<String>>()
         .join(" ")
+}
+
+/// Converts a command, and specified environment variables to user readable string
+///
+///
+/// Useful for showing usage of a command that uses environment variables for configuration.
+///
+/// This safer alternative to [`display_with_env_keys`] resolves environment variables from
+/// [`Command::get_resolved_envs`]. That function will automatically account for
+/// inherited environment variables and any env modifications such as [`Command::env_clear`]
+/// or [`Command::env_remove`.
+///
+/// ## Example
+///
+/// ```rust
+/// use std::process::Command;
+/// use fun_run;
+///
+/// let mut command = Command::new("bundle");
+/// command.arg("install").envs([("RAILS_ENV", "production")]);
+///
+/// let name = fun_run::display_env_keys(&mut command, ["RAILS_ENV"]);
+/// assert_eq!(String::from(r#"RAILS_ENV="production" bundle install"#), name);
+/// ```
+#[must_use]
+#[cfg(command_resolved_envs)]
+pub fn display_env_keys<T, K>(cmd: &mut Command, keys: T) -> String
+where
+    T: IntoIterator<Item = K>,
+    K: Into<OsString>,
+{
+    let env: HashMap<OsString, OsString> = cmd.get_resolved_envs().collect();
+    display_with_env_keys(cmd, env, keys)
 }
 
 /// Converts a command, arguments, and specified environment variables to user readable string
@@ -822,7 +848,7 @@ where
     let env = env
         .into_iter()
         .map(|(k, v)| (k.into(), v.into()))
-        .collect::<std::collections::HashMap<OsString, OsString>>();
+        .collect::<HashMap<OsString, OsString>>();
 
     keys.into_iter()
         .map(|key| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub trait CommandWithName {
     ///
     /// Useful for showing usage of a command that uses environment variables for configuration.
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```
     /// use fun_run::CommandWithName;
@@ -878,9 +878,9 @@ pub fn display(command: &mut Command) -> String {
 /// This safer alternative to [`display_with_env_keys`] resolves environment variables from
 /// [`Command::get_resolved_envs`]. That function will automatically account for
 /// inherited environment variables and any env modifications such as [`Command::env_clear`]
-/// or [`Command::env_remove`.
+/// or [`Command::env_remove`].
 ///
-/// ## Example
+/// # Examples
 ///
 /// ```rust
 /// use std::process::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(command_resolved_envs, feature(command_resolved_envs))]
 //! # Fun Run
 //!
 //! What does the "Zombie Zoom 5K", the "Wibbly wobbly log jog", and the "Turkey Trot" have in common?
@@ -230,6 +231,9 @@ use std::process::Output;
 use std::sync::LazyLock;
 #[cfg(feature = "which_problem")]
 use which_problem::Which;
+
+#[cfg(command_resolved_envs)]
+use std::{collections::HashMap, ffi::OsStr};
 
 mod command;
 
@@ -1291,6 +1295,19 @@ impl std::error::Error for IoErrorAnnotation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Nightly CI greps for this test name; update ci.yml if you rename it.
+    #[test]
+    #[cfg(command_resolved_envs)]
+    fn get_resolved_envs_detects_nightly_feature() {
+        let mut cmd = Command::new("does-not-run");
+        cmd.env("FUN_RUN_TEST_VAR", "1");
+        let resolved: HashMap<OsString, OsString> = cmd.get_resolved_envs().collect();
+        assert_eq!(
+            resolved.get(OsStr::new("FUN_RUN_TEST_VAR")),
+            Some(&OsString::from("1"))
+        );
+    }
 
     #[test]
     fn test_status_from_code() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! ## Nightly-only items
 //!
-//! A few items (`display_env_keys` and `CommandWithName::named_keys`) require a
+//! A few items (`display_env_keys` and `CommandWithName::named_env_vars`) require a
 //! nightly toolchain. They depend on the unstable
 //! [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
 //! feature, auto-detected at build time, and are absent on stable. Because
@@ -331,12 +331,17 @@ pub trait CommandWithName {
 
     /// Adds given environment variables to the command's name
     ///
+    /// Takes an environment variable **key** and if it will be used when the command runs
+    /// prepends the `<key>=<value>` pair to the front of the command.
+    ///
+    /// **Warning:** By default a [`Command`] will inherit environment variables from the parent process.
+    /// Limit environment variables to non-sensitive keys or use [`Command::env_clear`] and explicitly
+    /// [`Command::envs`] to set only what you need.
+    ///
     /// **Note:** Requires a nightly toolchain. This method relies on the unstable
     /// [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
     /// feature, which is auto-detected at build time. On a stable toolchain it does
     /// not exist, so calling it (or referring to it) will not compile.
-    ///
-    /// Useful for showing usage of a command that uses environment variables for configuration.
     ///
     /// # Examples
     ///
@@ -348,7 +353,7 @@ pub trait CommandWithName {
     ///     .arg("install")
     ///     .env("BUNDLE_WITHOUT", "development:test");
     ///
-    /// let mut cmd = command.named_keys(["BUNDLE_WITHOUT"]);
+    /// let mut cmd = command.named_env_vars(["BUNDLE_WITHOUT"]);
     /// assert_eq!(
     ///     r#"BUNDLE_WITHOUT="development:test" bundle install"#,
     ///     cmd.name()
@@ -369,20 +374,19 @@ pub trait CommandWithName {
     ///     ]);
     ///
     /// let mut cmd = command.named("./bin/bundle install");
-    /// let mut cmd = cmd.named_keys(["BUNDLE_WITHOUT"]);
+    /// let mut cmd = cmd.named_env_vars(["BUNDLE_WITHOUT"]);
     ///
     /// assert_eq!(
     ///     r#"BUNDLE_WITHOUT="development:test" ./bin/bundle install"#,
     ///     cmd.name()
     /// );
     ///
-    /// let mut cmd = cmd.named_keys(["BUNDLE_PATH"]);
+    /// let mut cmd = cmd.named_env_vars(["BUNDLE_PATH"]);
     /// assert_eq!(
     ///     r#"BUNDLE_PATH="vendor/bundle" BUNDLE_WITHOUT="development:test" ./bin/bundle install"#,
     ///     cmd.name()
     /// );
     /// ```
-    ///
     ///
     /// Re-naming a command that previously had an environment variable prepended will NOT
     /// preserve the environment variables.
@@ -393,7 +397,8 @@ pub trait CommandWithName {
     /// a stability guarantee.
     #[cfg(command_resolved_envs)]
     #[allow(clippy::needless_lifetimes)]
-    fn named_keys<'a, T, K>(&'a mut self, keys: T) -> NamedCommand<'a>
+    #[must_use]
+    fn named_env_vars<'a, T, K>(&'a mut self, keys: T) -> NamedCommand<'a>
     where
         T: IntoIterator<Item = K>,
         K: Into<OsString>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,7 +755,7 @@ static QUOTE_ARG_RE: LazyLock<Regex> =
 
 /// Converts a command and its arguments into a user readable string
 ///
-/// Example
+/// # Examples
 ///
 /// ```rust
 /// use std::process::Command;
@@ -786,7 +786,9 @@ pub fn display(command: &mut Command) -> String {
 
 /// Converts a command, arguments, and specified environment variables to user readable string
 ///
-/// Example
+/// Useful for showing usage of a command that uses environment variables for configuration.
+///
+/// # Examples
 ///
 /// ```rust
 /// use std::process::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,81 @@ pub trait CommandWithName {
         self.named(name)
     }
 
+    /// Adds given environment variables to the command's name
+    ///
+    /// Useful for showing usage of a command that uses environment variables for configuration.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use fun_run::CommandWithName;
+    ///
+    /// let mut command = std::process::Command::new("bundle");
+    /// command
+    ///     .arg("install")
+    ///     .env("BUNDLE_WITHOUT", "development:test");
+    ///
+    /// let mut cmd = command.named_keys(["BUNDLE_WITHOUT"]);
+    /// assert_eq!(
+    ///     r#"BUNDLE_WITHOUT="development:test" bundle install"#,
+    ///     cmd.name()
+    /// );
+    /// ```
+    ///
+    /// Preserves prior re-naming:
+    ///
+    /// ```
+    /// use fun_run::CommandWithName;
+    ///
+    /// let mut command = std::process::Command::new("bundle");
+    /// command
+    ///     .arg("install")
+    ///     .envs([
+    ///         ("BUNDLE_WITHOUT", "development:test"),
+    ///         ("BUNDLE_PATH", "vendor/bundle")
+    ///     ]);
+    ///
+    /// let mut cmd = command.named("./bin/bundle install");
+    /// let mut cmd = cmd.named_keys(["BUNDLE_WITHOUT"]);
+    ///
+    /// assert_eq!(
+    ///     r#"BUNDLE_WITHOUT="development:test" ./bin/bundle install"#,
+    ///     cmd.name()
+    /// );
+    ///
+    /// let mut cmd = cmd.named_keys(["BUNDLE_PATH"]);
+    /// assert_eq!(
+    ///     r#"BUNDLE_PATH="vendor/bundle" BUNDLE_WITHOUT="development:test" ./bin/bundle install"#,
+    ///     cmd.name()
+    /// );
+    /// ```
+    ///
+    ///
+    /// Re-naming a command that previously had an environment variable prepended will NOT
+    /// preserve the environment variables.
+    ///
+    /// This function is NOT (currently) idempotent. Calling it twice will prepend
+    /// the same environment variable twice. This behavior might change in the future (such that
+    /// under some conditions is becomes idempotent). Therefore you shouldn't consider this warning
+    /// a stability guarantee.
+    #[cfg(command_resolved_envs)]
+    #[allow(clippy::needless_lifetimes)]
+    fn named_keys<'a, T, K>(&'a mut self, keys: T) -> NamedCommand<'a>
+    where
+        T: IntoIterator<Item = K>,
+        K: Into<OsString>,
+    {
+        let old = self.name();
+        let cmd = self.mut_cmd();
+        let name = display_name_with_env_keys(
+            old,
+            cmd.get_resolved_envs()
+                .collect::<HashMap<OsString, OsString>>(),
+            keys,
+        );
+        self.named(name)
+    }
+
     /// Runs the command without streaming
     ///
     /// It's like [`Command::output`] but all the outputs carry the name of the original
@@ -779,7 +854,6 @@ pub fn display(command: &mut Command) -> String {
 
 /// Converts a command, and specified environment variables to user readable string
 ///
-///
 /// Useful for showing usage of a command that uses environment variables for configuration.
 ///
 /// This safer alternative to [`display_with_env_keys`] resolves environment variables from
@@ -845,6 +919,17 @@ where
     I: IntoIterator<Item = O>,
     O: Into<OsString>,
 {
+    display_name_with_env_keys(cmd.name(), env, keys)
+}
+
+fn display_name_with_env_keys<E, K, V, I, O>(name: String, env: E, keys: I) -> String
+where
+    E: IntoIterator<Item = (K, V)>,
+    K: Into<OsString>,
+    V: Into<OsString>,
+    I: IntoIterator<Item = O>,
+    O: Into<OsString>,
+{
     let env = env
         .into_iter()
         .map(|(k, v)| (k.into(), v.into()))
@@ -859,7 +944,7 @@ where
                 env.get(&key).cloned().unwrap_or_else(|| OsString::from(""))
             )
         })
-        .chain([display(cmd)])
+        .chain([name])
         .collect::<Vec<String>>()
         .join(" ")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,15 +68,6 @@
 //! );
 //! ```
 //!
-//! ## Nightly-only items
-//!
-//! A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
-//! nightly toolchain. They depend on the unstable
-//! [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
-//! feature, auto-detected at build time, and are absent on stable. Because
-//! <https://docs.rs> builds on nightly, these appear in the published docs even
-//! though stable users cannot use them.
-//!
 //! ## Install
 //!
 //! ```shell
@@ -228,6 +219,15 @@
 //!
 //! Note that `which_problem` integration is not enabled by default because it outputs information
 //! about the contents of your disk such as layout and file permissions.
+//!
+//! ## Nightly-only items
+//!
+//! A few items (`display_env_vars` and `CommandWithName::named_env_vars`) require a
+//! nightly toolchain. They depend on the unstable
+//! [`command_resolved_envs`](https://github.com/rust-lang/rust/issues/149070)
+//! feature, auto-detected at build time, and are absent on stable. Because
+//! <https://docs.rs> builds on nightly, these appear in the published docs even
+//! though stable users cannot use them.
 
 use command::output_and_write_streams;
 use regex::Regex;


### PR DESCRIPTION
Tracking issue https://github.com/rust-lang/rust/issues/149070 is mine, and the feature is mine. The original idea is that such features would be useful for this library (or others like it). I want to provide stabilization feedback eventually.

- Introduce `fun_run::display_env_vars()` (for nightly users). This pulls environment variables from the command (using a nightly feature) and provides a better interface than `fun_run::display_with_env_keys` (which requires externally inserted environment variables). If this feature is stabilized in Rust then `display_with_env_keys` will be deprecated.
- Introduce `named_env_vars` function to the `CommandWithName` trait (for nightly users). This function helps decorate a command's name with the given environment variable keys.